### PR TITLE
Add support for ShiftJIS art and /qst/ colored text

### DIFF
--- a/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
@@ -1261,3 +1261,12 @@ code.hljs {
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
     font-size: 16px !important;
 }
+.qst-color.red {
+    color: #c41e3a;
+}
+.qst-color.green {
+    color: #00a550;
+}
+.qst-color.blue {
+    color: #1d8dc4;
+}

--- a/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
@@ -1260,6 +1260,7 @@ code.hljs {
 .shift-jis {
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
     font-size: 16px !important;
+    white-space: pre;
 }
 .qst-color.red {
     color: #c41e3a;

--- a/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
@@ -1260,8 +1260,10 @@ code.hljs {
 .shift-jis {
     font-size: 16px;
     line-height: 17px;
-    white-space: pre;
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace;
+}
+span.shift-jis {
+    white-space: pre;
     overflow: auto;
 }
 .qst-color.red {

--- a/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
@@ -29,9 +29,6 @@
 .theme_default p {
   margin: 2px 0 7px;
 }
-.theme_default .shift-jis {
-  font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, sans-serif !important;
-  font-size: 16px !important;
 }
 .theme_default ::-moz-selection {
   background: #fe57a1;
@@ -1259,4 +1256,8 @@ code.hljs {
 }
 .theme_default.midnight span.highlight {
   background: #000000;
+}
+.shift-jis {
+    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
+    font-size: 16px !important;
 }

--- a/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.css
@@ -1258,9 +1258,11 @@ code.hljs {
   background: #000000;
 }
 .shift-jis {
-    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
-    font-size: 16px !important;
+    font-size: 16px;
+    line-height: 17px;
     white-space: pre;
+    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace;
+    overflow: auto;
 }
 .qst-color.red {
     color: #c41e3a;

--- a/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.less
+++ b/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.less
@@ -27,10 +27,6 @@
 	p {
 		margin:2px 0 7px;
 	}
-	.shift-jis {
-		font-family:'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, sans-serif !important;
-		font-size:16px !important;
-	}
 	::-moz-selection {
 		background:#fe57a1;
 		color:#ffffff;
@@ -1198,4 +1194,8 @@ a.visited {
 }
 .theme_default.midnight .table-striped tbody tr:nth-child(2n+1) td, .table-striped tbody tr:nth-child(2n+1) th {
 	background-color:#282a2e;
+}
+.shift-jis {
+		font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
+		font-size: 16px !important;
 }

--- a/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.less
+++ b/assets/themes/foolz/foolfuuka-theme-foolfuuka/assets/style.less
@@ -1199,3 +1199,14 @@ a.visited {
 		font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
 		font-size: 16px !important;
 }
+.qst-color {
+    &.red {
+        color: #c41e3a;
+    }
+    &.green {
+        color: #00a550;
+    }
+    &.blue {
+        color: #1d8dc4;
+    }
+}

--- a/assets/themes/foolz/foolfuuka-theme-foolfuuka/composer.json
+++ b/assets/themes/foolz/foolfuuka-theme-foolfuuka/composer.json
@@ -2,7 +2,7 @@
   "name": "foolz/foolfuuka-theme-foolfuuka",
   "type": "foolz-foolfuuka-theme",
   "description": "The default FoolFuuka theme.",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "keywords": [
     "theme",
     "default",

--- a/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
@@ -281,6 +281,15 @@ code,
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
     font-size: 16px !important;
 }
+.qst-color.red {
+    color: #c41e3a;
+}
+.qst-color.green {
+    color: #00a550;
+}
+.qst-color.blue {
+    color: #1d8dc4;
+}
 .mod {
   color: #800080 !important;
 }

--- a/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
@@ -280,6 +280,7 @@ code,
 .shift-jis {
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
     font-size: 16px !important;
+    white-space: pre;
 }
 .qst-color.red {
     color: #c41e3a;

--- a/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
@@ -278,9 +278,11 @@ code,
   color: red;
 }
 .shift-jis {
-    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
-    font-size: 16px !important;
+    font-size: 16px;
+    line-height: 17px;
     white-space: pre;
+    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace;
+    overflow: auto;
 }
 .qst-color.red {
     color: #c41e3a;

--- a/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
@@ -280,8 +280,10 @@ code,
 .shift-jis {
     font-size: 16px;
     line-height: 17px;
-    white-space: pre;
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace;
+}
+span.shift-jis {
+    white-space: pre;
     overflow: auto;
 }
 .qst-color.red {

--- a/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.css
@@ -277,6 +277,10 @@ code,
   font-weight: bold;
   color: red;
 }
+.shift-jis {
+    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
+    font-size: 16px !important;
+}
 .mod {
   color: #800080 !important;
 }

--- a/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.less
+++ b/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.less
@@ -275,6 +275,10 @@ code, .code {
 	font-weight:bold;
 	color:red;
 }
+.shift-jis {
+    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
+    font-size: 16px !important;
+}
 .mod {
 	color:#800080 !important;
 }

--- a/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.less
+++ b/assets/themes/foolz/foolfuuka-theme-fuuka/assets/style.less
@@ -279,6 +279,17 @@ code, .code {
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
     font-size: 16px !important;
 }
+.qst-color {
+    &.red {
+        color: #c41e3a;
+    }
+    &.green {
+        color: #00a550;
+    }
+    &.blue {
+        color: #1d8dc4;
+    }
+}
 .mod {
 	color:#800080 !important;
 }

--- a/assets/themes/foolz/foolfuuka-theme-fuuka/composer.json
+++ b/assets/themes/foolz/foolfuuka-theme-fuuka/composer.json
@@ -2,7 +2,7 @@
   "name": "foolz/foolfuuka-theme-fuuka",
   "type": "foolz-foolfuuka-theme",
   "description": "The fuuka FoolFuuka theme.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "keywords": [
     "theme",
     "default",

--- a/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
@@ -228,9 +228,11 @@ body.theme_default.yotsuba_b {
   top: -1px;
 }
 .theme_default .shift-jis {
-    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
-    font-size: 16px !important;
+    font-size: 16px;
+    line-height: 17px;
     white-space: pre;
+    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace;
+    overflow: auto;
 }
 .theme_default .qst-color.red {
     color: #c41e3a;

--- a/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
@@ -231,6 +231,15 @@ body.theme_default.yotsuba_b {
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
     font-size: 16px !important;
 }
+.theme_default .qst-color.red {
+    color: #c41e3a;
+}
+.theme_default .qst-color.green {
+    color: #00a550;
+}
+.theme_default .qst-color.blue {
+    color: #1d8dc4;
+}
 .navbar-search .search-query {
   box-shadow: none;
 }

--- a/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
@@ -227,6 +227,10 @@ body.theme_default.yotsuba_b {
   line-height: 11px;
   top: -1px;
 }
+.theme_default .shift-jis {
+    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
+    font-size: 16px !important;
+}
 .navbar-search .search-query {
   box-shadow: none;
 }

--- a/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
@@ -230,6 +230,7 @@ body.theme_default.yotsuba_b {
 .theme_default .shift-jis {
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
     font-size: 16px !important;
+    white-space: pre;
 }
 .theme_default .qst-color.red {
     color: #c41e3a;

--- a/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
+++ b/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.css
@@ -230,8 +230,10 @@ body.theme_default.yotsuba_b {
 .theme_default .shift-jis {
     font-size: 16px;
     line-height: 17px;
-    white-space: pre;
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace;
+}
+.theme_default span.shift-jis {
+    white-space: pre;
     overflow: auto;
 }
 .theme_default .qst-color.red {

--- a/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.less
+++ b/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.less
@@ -231,6 +231,15 @@ body.theme_default.yotsuba_b {
     font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
     font-size: 16px !important;
 }
+.theme_default .qst-color.red {
+    color: #c41e3a;
+}
+.theme_default .qst-color.green {
+    color: #00a550;
+}
+.theme_default .qst-color.blue {
+    color: #1d8dc4;
+}
 .navbar-search .search-query {
 	box-shadow:none;
 }

--- a/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.less
+++ b/assets/themes/foolz/foolfuuka-theme-yotsubatwo/assets/style.less
@@ -227,6 +227,10 @@ body.theme_default.yotsuba_b {
 	line-height:11px;
 	top:-1px;
 }
+.theme_default .shift-jis {
+    font-family: 'IPAMonaPGothic', 'IPA モナー Pゴシック', Mona, 'MS PGothic', 'ＭＳ Ｐゴシック', Osaka, YOzFontAA97, monospace !important;
+    font-size: 16px !important;
+}
 .navbar-search .search-query {
 	box-shadow:none;
 }

--- a/assets/themes/foolz/foolfuuka-theme-yotsubatwo/composer.json
+++ b/assets/themes/foolz/foolfuuka-theme-yotsubatwo/composer.json
@@ -2,7 +2,7 @@
   "name": "foolz/foolfuuka-theme-yotsubatwo",
   "type": "foolz-foolfuuka-theme",
   "description": "The YotsubaTwo FoolFuuka theme.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "keywords": [
     "theme",
     "default",

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -441,6 +441,9 @@ class Comment extends Model
             $builder->setUseOption(true);
             array_push($definitions, $builder->build());
 
+            $builder = new \JBBCode\CodeDefinitionBuilder('shiftjis', '<span class="shift-jis">{param}</span>');
+            array_push($definitions, $builder->build());
+
             $definitions = Hook::forge('Foolz\FoolFuuka\Model\Comment::processCommentBBCode#var.definitions')
                 ->setObject($this)
                 ->setParam('definitions', $definitions)

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -444,6 +444,10 @@ class Comment extends Model
             $builder = new \JBBCode\CodeDefinitionBuilder('shiftjis', '<span class="shift-jis">{param}</span>');
             array_push($definitions, $builder->build());
 
+            $builder = new \JBBCode\CodeDefinitionBuilder('qstcolor', '<span class="qst-color {option}">{param}</span>');
+            $builder->setUseOption(true);
+            array_push($definitions, $builder->build());
+
             $definitions = Hook::forge('Foolz\FoolFuuka\Model\Comment::processCommentBBCode#var.definitions')
                 ->setObject($this)
                 ->setParam('definitions', $definitions)


### PR DESCRIPTION
Both the CSS and Less files have been updated, even though it seems that Less isn't being used anymore.

The fallback font for the ShiftJIS art was changed from sans serif to monospace. This is more in line with 4chan's current styles, which are a bit more extensive:
```css
.sjis, #quickReply .sjis {
  font-size: 16px;
  line-height: 17px;
  white-space: pre;
  font-family: 'IPAMonaPGothic', 'Mona', 'MS PGothic', monospace;
  overflow: auto;
  display: block;
  clear: left;
}
```
I'm not sure if all the other stuff is needed, but it wouldn't be too hard to add it in.

I also tested out the /qst/ colored text on all the themes, and it seems readable enough. So I didn't change it from what 4chan has.