### PR TITLE
Fix error when deleted posts appear in searches

### DIFF
--- a/src/Model/Search.php
+++ b/src/Model/Search.php
@@ -572,6 +572,10 @@ class Search extends Board
                 ->executeQuery($sql)
                 ->fetchAll();
 
+            if (!count($result)) {
+                continue;
+            }
+
             $board = ($this->radix !== null ? $this->radix : $this->radix_coll->getById($result[0]['board_id']));
             $bulk = new CommentBulk();
             $bulk->import($result[0], $board);
@@ -579,7 +583,7 @@ class Search extends Board
         }
 
         // no results found IN DATABASE, but we might still get a search count from Sphinx
-        if (!count($result)) {
+        if (!$this->comments_unsorted) {
             $this->comments_unsorted = [];
             $this->comments = [];
         }


### PR DESCRIPTION
We ran into this on desuarchive recently, it was introduced in https://github.com/pleebe/FoolFuuka/commit/d9b457dea85db630fa4f5e39df8a984596060566.